### PR TITLE
Fix: Resolve 'Unresolved reference Screen' in NavHost

### DIFF
--- a/app/src/main/java/com/dejvik/stretchhero/navigation/Screen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/navigation/Screen.kt
@@ -1,0 +1,8 @@
+package com.dejvik.stretchhero.navigation
+
+sealed class Screen(val route: String) {
+    object StretchLibrary : Screen("stretchLibrary")
+    object RoutineDetail : Screen("routineDetail/{routineId}") {
+        fun createRoute(routineId: String) = "routineDetail/$routineId"
+    }
+}

--- a/app/src/main/java/com/dejvik/stretchhero/navigation/StretchHeroNavHost.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/navigation/StretchHeroNavHost.kt
@@ -1,5 +1,6 @@
 package com.dejvik.stretchhero.navigation
 
+import com.dejvik.stretchhero.navigation.Screen // Added import
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text


### PR DESCRIPTION
- I've defined a new sealed class `Screen` in `navigation/Screen.kt` to encapsulate navigation routes.
- I've also updated `StretchHeroNavHost.kt` to import and use this `Screen` class.
- Finally, I verified that `StretchLibraryScreen.kt` correctly uses `Screen.RoutineDetail.createRoute()` for navigation.

This commit should resolve the compilation error related to the undefined 'Screen' identifier in the navigation setup.