### PR TITLE
Fix: Add OptIn for ExperimentalMaterial3Api in StretchRoutineScreen

### DIFF
--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
@@ -1,5 +1,6 @@
 package com.dejvik.stretchhero.ui.screens
 
+import androidx.compose.material3.ExperimentalMaterial3Api // Added import
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
@@ -26,6 +27,7 @@ import com.dejvik.stretchhero.ui.theme.MutedRed
 import com.dejvik.stretchhero.ui.theme.SoftWhite
 import com.dejvik.stretchhero.ui.theme.montserratFont
 
+@OptIn(ExperimentalMaterial3Api::class) // Added annotation
 @Composable
 fun StretchRoutineScreen(
     navController: NavController,


### PR DESCRIPTION
- Added `@OptIn(ExperimentalMaterial3Api::class)` to the `StretchRoutineScreen` composable.
- Imported `androidx.compose.material3.ExperimentalMaterial3Api`.

This addresses the build warning regarding the use of experimental `TopAppBar` API.