### PR TITLE
Fix: Attempt to resolve persistent 'Unresolved reference FontFamily'

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation("androidx.compose.ui:ui:1.5.3")
     implementation("androidx.compose.material3:material3:1.1.2")
     implementation("androidx.navigation:navigation-compose:2.7.5")
-    implementation("androidx.compose.ui:ui-text-google-fonts:1.0.0")
+    implementation("androidx.compose.ui:ui-text-google-fonts:1.6.0")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/dejvik/stretchhero/ui/theme/Theme.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/theme/Theme.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily // Added import
 
 
 


### PR DESCRIPTION
This commit includes several changes aimed at resolving the 'Unresolved reference FontFamily' error in Theme.kt:

- Thoroughly re-verified font definitions and imports in `Type.kt` and `Theme.kt`.
- Updated the `androidx.compose.ui:ui-text-google-fonts` dependency from version 1.0.0 to 1.6.0.
- Added a diagnostic import for `FontFamily` in `Theme.kt`.

Hoping these changes, combined with a cache invalidation and clean build, will resolve the issue.