### PR TITLE
Fix: Update ui-text-google-fonts and verify FontProvider import

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation("androidx.compose.ui:ui:1.5.3")
     implementation("androidx.compose.material3:material3:1.1.2")
     implementation("androidx.navigation:navigation-compose:2.7.5")
-    implementation("androidx.compose.ui:ui-text-google-fonts:1.6.0")
+    implementation("androidx.compose.ui:ui-text-google-fonts:1.6.7")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))


### PR DESCRIPTION
- I've updated the `androidx.compose.ui:ui-text-google-fonts` dependency from 1.6.0 to 1.6.7.
- I've also verified that `Type.kt` correctly imports `androidx.compose.ui.text.googlefonts.FontProvider`.

This should resolve the "Unresolved reference 'FontProvider'" error you were seeing.