### PR TITLE
Diagnose: Temporarily remove Google Fonts code and dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     // implementation("androidx.compose.ui:ui:1.5.3") // Removed for BOM
     // implementation("androidx.compose.material3:material3:1.1.2") // Removed for BOM
     implementation("androidx.navigation:navigation-compose:2.7.5")
-    implementation("androidx.compose.ui:ui-text-google-fonts:1.6.7")
+    // implementation("androidx.compose.ui:ui-text-google-fonts:1.6.7") // Commented out
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
@@ -3,12 +3,13 @@ package com.dejvik.stretchhero.ui.theme
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.googlefonts.Font
-import androidx.compose.ui.text.googlefonts.FontProvider
-import androidx.compose.ui.text.googlefonts.GoogleFont
+// import androidx.compose.ui.text.googlefonts.Font // Commented out
+// import androidx.compose.ui.text.googlefonts.FontProvider // Commented out
+// import androidx.compose.ui.text.googlefonts.GoogleFont // Commented out
 import androidx.compose.ui.unit.sp
 import com.dejvik.stretchhero.R
 
+/* Commented out montserratFont definition
 val montserratFont = FontFamily(
     Font(
         googleFont = GoogleFont("Montserrat"),
@@ -19,22 +20,23 @@ val montserratFont = FontFamily(
         )
     )
 )
+*/
 
 // Define the Typography object
 val Typography = Typography(
-    displayLarge = TextStyle(fontFamily = montserratFont),
-    displayMedium = TextStyle(fontFamily = montserratFont),
-    displaySmall = TextStyle(fontFamily = montserratFont),
-    headlineLarge = TextStyle(fontFamily = montserratFont),
-    headlineMedium = TextStyle(fontFamily = montserratFont),
-    headlineSmall = TextStyle(fontFamily = montserratFont), // As used in StretchLibraryScreen
-    titleLarge = TextStyle(fontFamily = montserratFont),
-    titleMedium = TextStyle(fontFamily = montserratFont),
-    titleSmall = TextStyle(fontFamily = montserratFont),
-    bodyLarge = TextStyle(fontFamily = montserratFont),    // As used in StretchLibraryScreen & StretchRoutineScreen
-    bodyMedium = TextStyle(fontFamily = montserratFont),   // As used in StretchRoutineScreen
-    bodySmall = TextStyle(fontFamily = montserratFont),
-    labelLarge = TextStyle(fontFamily = montserratFont),
-    labelMedium = TextStyle(fontFamily = montserratFont),
-    labelSmall = TextStyle(fontFamily = montserratFont)
+    displayLarge = TextStyle(fontFamily = FontFamily.Default),
+    displayMedium = TextStyle(fontFamily = FontFamily.Default),
+    displaySmall = TextStyle(fontFamily = FontFamily.Default),
+    headlineLarge = TextStyle(fontFamily = FontFamily.Default),
+    headlineMedium = TextStyle(fontFamily = FontFamily.Default),
+    headlineSmall = TextStyle(fontFamily = FontFamily.Default), // As used in StretchLibraryScreen
+    titleLarge = TextStyle(fontFamily = FontFamily.Default),
+    titleMedium = TextStyle(fontFamily = FontFamily.Default),
+    titleSmall = TextStyle(fontFamily = FontFamily.Default),
+    bodyLarge = TextStyle(fontFamily = FontFamily.Default),    // As used in StretchLibraryScreen & StretchRoutineScreen
+    bodyMedium = TextStyle(fontFamily = FontFamily.Default),   // As used in StretchRoutineScreen
+    bodySmall = TextStyle(fontFamily = FontFamily.Default),
+    labelLarge = TextStyle(fontFamily = FontFamily.Default),
+    labelMedium = TextStyle(fontFamily = FontFamily.Default),
+    labelSmall = TextStyle(fontFamily = FontFamily.Default)
 )


### PR DESCRIPTION
- I commented out the `montserratFont` definition and its usage in `Type.kt`.
- I commented out related googlefonts imports in `Type.kt`.
- I changed `Typography` in `Type.kt` to use `FontFamily.Default`.
- I commented out the `androidx.compose.ui:ui-text-google-fonts` dependency in `app/build.gradle.kts`.

This is a diagnostic step to check if the project compiles cleanly without the downloadable fonts feature, to isolate the persistent "Unresolved reference" errors.