### PR TITLE
To diagnose the compilation issue, I've made some changes:

### DIFF
--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchLibraryScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchLibraryScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontFamily // Ensured import
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -50,6 +51,7 @@ fun StretchLibraryScreen(navController: NavController) {
         Text(
             text = "Stretch Routines",
             fontSize = 28.sp,
+            fontFamily = FontFamily.Default, // Changed from montserratFont (implicitly, as it's not set)
             fontWeight = FontWeight.Bold,
             modifier = Modifier.padding(bottom = 24.dp),
             color = Color(0xFF333333) // Darker text color
@@ -94,6 +96,7 @@ fun RoutineCard(routine: Routine, navController: NavController) {
                 Text(
                     text = routine.name,
                     fontSize = 20.sp, // Slightly larger title
+                    fontFamily = FontFamily.Default, // Changed from montserratFont (implicitly, as it's not set)
                     fontWeight = FontWeight.SemiBold,
                     color = Color(0xFF333333)
                 )
@@ -101,6 +104,7 @@ fun RoutineCard(routine: Routine, navController: NavController) {
                 Text(
                     text = "Estimated time: ${routine.steps.sumOf { it.duration } / 60} min",
                     fontSize = 14.sp,
+                    fontFamily = FontFamily.Default, // Changed from montserratFont (implicitly, as it's not set)
                     color = Color.Gray
                 )
             }

--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
@@ -25,7 +25,8 @@ import com.dejvik.stretchhero.R
 import com.dejvik.stretchhero.utils.TextToSpeechHelper
 import com.dejvik.stretchhero.ui.theme.MutedRed
 import com.dejvik.stretchhero.ui.theme.SoftWhite
-import com.dejvik.stretchhero.ui.theme.montserratFont
+// import com.dejvik.stretchhero.ui.theme.montserratFont // Commented out as it's replaced by FontFamily.Default
+import androidx.compose.ui.text.font.FontFamily // Ensured import
 
 @OptIn(ExperimentalMaterial3Api::class) // Added annotation
 @Composable
@@ -82,7 +83,7 @@ fun StretchRoutineScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(currentRoutine?.name ?: "Loading...", fontFamily = montserratFont, color = SoftWhite) },
+                title = { Text(currentRoutine?.name ?: "Loading...", fontFamily = FontFamily.Default, color = SoftWhite) },
                 navigationIcon = {
                     IconButton(onClick = {
                         viewModel.stopTimer()
@@ -109,7 +110,7 @@ fun StretchRoutineScreen(
                     text = "Routine not found. Please go back and select a valid routine.",
                     fontSize = 20.sp,
                     color = SoftWhite,
-                    fontFamily = montserratFont,
+                    fontFamily = FontFamily.Default,
                     modifier = Modifier.padding(horizontal = 32.dp)
                 )
             }
@@ -141,7 +142,7 @@ fun StretchRoutineScreen(
                 Text(
                     text = currentStep.name,
                     fontSize = 24.sp,
-                    fontFamily = montserratFont,
+                    fontFamily = FontFamily.Default,
                     color = SoftWhite,
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
@@ -167,7 +168,7 @@ fun StretchRoutineScreen(
                     // Display the animated time, or the step duration if timer not running and it's full
                     text = if (isRunning || timeLeft < currentStep.duration) "$animatedTimeLeft s" else "${currentStep.duration} s",
                     fontSize = 48.sp,
-                    fontFamily = montserratFont,
+                    fontFamily = FontFamily.Default,
                     color = SoftWhite,
                     modifier = Modifier.padding(bottom = 16.dp)
                 )


### PR DESCRIPTION
- I updated StretchRoutineScreen.kt and StretchLibraryScreen.kt to use FontFamily.Default instead of direct references to montserratFont.
- This is part of the diagnostic effort to achieve a clean compile by temporarily removing all custom font code.