### PR TITLE
Feat: Restore homescreen and re-enable Montserrat font

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     // implementation("androidx.compose.ui:ui:1.5.3") // Removed for BOM
     // implementation("androidx.compose.material3:material3:1.1.2") // Removed for BOM
     implementation("androidx.navigation:navigation-compose:2.7.5")
-    // implementation("androidx.compose.ui:ui-text-google-fonts:1.6.7") // Commented out
+    implementation("androidx.compose.ui:ui-text-google-fonts:1.6.7") // Uncommented
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/dejvik/stretchhero/navigation/Screen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/navigation/Screen.kt
@@ -1,6 +1,7 @@
 package com.dejvik.stretchhero.navigation
 
 sealed class Screen(val route: String) {
+    object Home : Screen("home") // Added Home screen
     object StretchLibrary : Screen("stretchLibrary")
     object RoutineDetail : Screen("routineDetail/{routineId}") {
         fun createRoute(routineId: String) = "routineDetail/$routineId"

--- a/app/src/main/java/com/dejvik/stretchhero/navigation/StretchHeroNavHost.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/navigation/StretchHeroNavHost.kt
@@ -11,6 +11,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.dejvik.stretchhero.ui.screens.HomeScreen // Added import
 import com.dejvik.stretchhero.ui.screens.StretchLibraryScreen
 import com.dejvik.stretchhero.ui.screens.StretchRoutineScreen
 import com.dejvik.stretchhero.ui.theme.DarkGray
@@ -21,9 +22,12 @@ fun StretchHeroNavHost() {
     Scaffold(containerColor = DarkGray) { padding ->
         NavHost(
             navController = navController,
-            startDestination = Screen.StretchLibrary.route,
+            startDestination = Screen.Home.route, // Changed startDestination
             modifier = Modifier.padding(padding)
         ) {
+            composable(Screen.Home.route) { // Added HomeScreen composable
+                HomeScreen(navController)
+            }
             composable(Screen.StretchLibrary.route) {
                 StretchLibraryScreen(navController)
             }

--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/HomeScreen.kt
@@ -1,0 +1,55 @@
+package com.dejvik.stretchhero.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+// import androidx.compose.ui.text.font.FontFamily // Commented out
+import com.dejvik.stretchhero.ui.theme.montserratFont // Added import
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.dejvik.stretchhero.navigation.Screen // Will be needed for navigation
+
+@Composable
+fun HomeScreen(navController: NavController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Stretch Hero",
+            fontSize = 32.sp,
+            fontFamily = montserratFont // Changed to montserratFont
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+        Button(onClick = {
+            navController.navigate(Screen.StretchLibrary.route)
+        }) {
+            Text("Begin Stretching")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HomeScreenPreview() {
+    // Preview requires a NavController, even if it's a dummy one for preview purposes.
+    // For MaterialTheme to apply, you might need to wrap this in your app's theme if it's not applying.
+    // com.dejvik.stretchhero.ui.theme.StretchHeroTheme { // Uncomment if needed for preview
+        HomeScreen(navController = rememberNavController())
+    // }
+}

--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchLibraryScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchLibraryScreen.kt
@@ -26,7 +26,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontFamily // Ensured import
+// import androidx.compose.ui.text.font.FontFamily // Commented out
+import com.dejvik.stretchhero.ui.theme.montserratFont // Added import
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -51,7 +52,7 @@ fun StretchLibraryScreen(navController: NavController) {
         Text(
             text = "Stretch Routines",
             fontSize = 28.sp,
-            fontFamily = FontFamily.Default, // Changed from montserratFont (implicitly, as it's not set)
+            fontFamily = montserratFont, // Changed to montserratFont
             fontWeight = FontWeight.Bold,
             modifier = Modifier.padding(bottom = 24.dp),
             color = Color(0xFF333333) // Darker text color
@@ -96,7 +97,7 @@ fun RoutineCard(routine: Routine, navController: NavController) {
                 Text(
                     text = routine.name,
                     fontSize = 20.sp, // Slightly larger title
-                    fontFamily = FontFamily.Default, // Changed from montserratFont (implicitly, as it's not set)
+                    fontFamily = montserratFont, // Changed to montserratFont
                     fontWeight = FontWeight.SemiBold,
                     color = Color(0xFF333333)
                 )
@@ -104,7 +105,7 @@ fun RoutineCard(routine: Routine, navController: NavController) {
                 Text(
                     text = "Estimated time: ${routine.steps.sumOf { it.duration } / 60} min",
                     fontSize = 14.sp,
-                    fontFamily = FontFamily.Default, // Changed from montserratFont (implicitly, as it's not set)
+                    fontFamily = montserratFont, // Changed to montserratFont
                     color = Color.Gray
                 )
             }

--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
@@ -25,8 +25,8 @@ import com.dejvik.stretchhero.R
 import com.dejvik.stretchhero.utils.TextToSpeechHelper
 import com.dejvik.stretchhero.ui.theme.MutedRed
 import com.dejvik.stretchhero.ui.theme.SoftWhite
-// import com.dejvik.stretchhero.ui.theme.montserratFont // Commented out as it's replaced by FontFamily.Default
-import androidx.compose.ui.text.font.FontFamily // Ensured import
+import com.dejvik.stretchhero.ui.theme.montserratFont // Added import
+// import androidx.compose.ui.text.font.FontFamily // Commented out
 
 @OptIn(ExperimentalMaterial3Api::class) // Added annotation
 @Composable
@@ -83,7 +83,7 @@ fun StretchRoutineScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(currentRoutine?.name ?: "Loading...", fontFamily = FontFamily.Default, color = SoftWhite) },
+                title = { Text(currentRoutine?.name ?: "Loading...", fontFamily = montserratFont, color = SoftWhite) },
                 navigationIcon = {
                     IconButton(onClick = {
                         viewModel.stopTimer()
@@ -110,7 +110,7 @@ fun StretchRoutineScreen(
                     text = "Routine not found. Please go back and select a valid routine.",
                     fontSize = 20.sp,
                     color = SoftWhite,
-                    fontFamily = FontFamily.Default,
+                    fontFamily = montserratFont,
                     modifier = Modifier.padding(horizontal = 32.dp)
                 )
             }
@@ -142,7 +142,7 @@ fun StretchRoutineScreen(
                 Text(
                     text = currentStep.name,
                     fontSize = 24.sp,
-                    fontFamily = FontFamily.Default,
+                    fontFamily = montserratFont,
                     color = SoftWhite,
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
@@ -168,7 +168,7 @@ fun StretchRoutineScreen(
                     // Display the animated time, or the step duration if timer not running and it's full
                     text = if (isRunning || timeLeft < currentStep.duration) "$animatedTimeLeft s" else "${currentStep.duration} s",
                     fontSize = 48.sp,
-                    fontFamily = FontFamily.Default,
+                    fontFamily = montserratFont,
                     color = SoftWhite,
                     modifier = Modifier.padding(bottom = 16.dp)
                 )

--- a/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
@@ -3,13 +3,13 @@ package com.dejvik.stretchhero.ui.theme
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
-// import androidx.compose.ui.text.googlefonts.Font // Commented out
-// import androidx.compose.ui.text.googlefonts.FontProvider // Commented out
-// import androidx.compose.ui.text.googlefonts.GoogleFont // Commented out
+import androidx.compose.ui.text.googlefonts.Font // Uncommented
+import androidx.compose.ui.text.googlefonts.FontProvider // Uncommented
+import androidx.compose.ui.text.googlefonts.GoogleFont // Uncommented
 import androidx.compose.ui.unit.sp
 import com.dejvik.stretchhero.R
 
-/* Commented out montserratFont definition
+// Uncommented montserratFont definition
 val montserratFont = FontFamily(
     Font(
         googleFont = GoogleFont("Montserrat"),
@@ -20,23 +20,22 @@ val montserratFont = FontFamily(
         )
     )
 )
-*/
 
 // Define the Typography object
 val Typography = Typography(
-    displayLarge = TextStyle(fontFamily = FontFamily.Default),
-    displayMedium = TextStyle(fontFamily = FontFamily.Default),
-    displaySmall = TextStyle(fontFamily = FontFamily.Default),
-    headlineLarge = TextStyle(fontFamily = FontFamily.Default),
-    headlineMedium = TextStyle(fontFamily = FontFamily.Default),
-    headlineSmall = TextStyle(fontFamily = FontFamily.Default), // As used in StretchLibraryScreen
-    titleLarge = TextStyle(fontFamily = FontFamily.Default),
-    titleMedium = TextStyle(fontFamily = FontFamily.Default),
-    titleSmall = TextStyle(fontFamily = FontFamily.Default),
-    bodyLarge = TextStyle(fontFamily = FontFamily.Default),    // As used in StretchLibraryScreen & StretchRoutineScreen
-    bodyMedium = TextStyle(fontFamily = FontFamily.Default),   // As used in StretchRoutineScreen
-    bodySmall = TextStyle(fontFamily = FontFamily.Default),
-    labelLarge = TextStyle(fontFamily = FontFamily.Default),
-    labelMedium = TextStyle(fontFamily = FontFamily.Default),
-    labelSmall = TextStyle(fontFamily = FontFamily.Default)
+    displayLarge = TextStyle(fontFamily = montserratFont),
+    displayMedium = TextStyle(fontFamily = montserratFont),
+    displaySmall = TextStyle(fontFamily = montserratFont),
+    headlineLarge = TextStyle(fontFamily = montserratFont),
+    headlineMedium = TextStyle(fontFamily = montserratFont),
+    headlineSmall = TextStyle(fontFamily = montserratFont), // As used in StretchLibraryScreen
+    titleLarge = TextStyle(fontFamily = montserratFont),
+    titleMedium = TextStyle(fontFamily = montserratFont),
+    titleSmall = TextStyle(fontFamily = montserratFont),
+    bodyLarge = TextStyle(fontFamily = montserratFont),    // As used in StretchLibraryScreen & StretchRoutineScreen
+    bodyMedium = TextStyle(fontFamily = montserratFont),   // As used in StretchRoutineScreen
+    bodySmall = TextStyle(fontFamily = montserratFont),
+    labelLarge = TextStyle(fontFamily = montserratFont),
+    labelMedium = TextStyle(fontFamily = montserratFont),
+    labelSmall = TextStyle(fontFamily = montserratFont)
 )


### PR DESCRIPTION
- Created a new HomeScreen with a title and a button to navigate to the stretch library.
- Updated navigation graph to set HomeScreen as the start destination.
- Re-enabled the Montserrat downloadable font:
    - Uncommented ui-text-google-fonts dependency (1.6.7).
    - Uncommented montserratFont definition and related imports in Type.kt.
    - Updated Typography object and direct usages in screens to use montserratFont.
- Ensured Kotlin version (2.0.0) and Compose Compiler Extension (1.5.10) are aligned.

This aims to restore the homescreen functionality and correctly implement the custom font, resolving previous compilation issues.