### PR TITLE
Diagnose: Use explicit Compose versions, remove BOM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,21 +52,21 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0") // For viewModelScope
     implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
+    // implementation(platform(libs.androidx.compose.bom)) // Commented out
+    implementation("androidx.compose.ui:ui:1.6.7") // Explicit version
+    implementation("androidx.compose.ui:ui-graphics:1.6.7") // Explicit version
+    implementation("androidx.compose.ui:ui-tooling-preview:1.6.7") // Explicit version
+    implementation("androidx.compose.material3:material3:1.2.1") // Explicit version
     testImplementation(libs.junit)
     implementation("androidx.activity:activity-compose:1.8.2")
     // implementation("androidx.compose.ui:ui:1.5.3") // Removed for BOM
     // implementation("androidx.compose.material3:material3:1.1.2") // Removed for BOM
     implementation("androidx.navigation:navigation-compose:2.7.5")
-    implementation("androidx.compose.ui:ui-text-google-fonts:1.6.7") // Uncommented
+    implementation("androidx.compose.ui:ui-text-google-fonts:1.6.7")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
+    // androidTestImplementation(platform(libs.androidx.compose.bom)) // Commented out for test as well
     androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
+    debugImplementation("androidx.compose.ui:ui-tooling:1.6.7") // Explicit version
     debugImplementation(libs.androidx.ui.test.manifest)
 }


### PR DESCRIPTION
- I commented out Compose BOM.
- I set explicit versions for core Compose libraries (ui, ui-graphics, ui-tooling-preview, material3) to 1.6.7 (material3 to 1.2.1) to align with ui-text-google-fonts:1.6.7.

This is a diagnostic step to try and resolve the persistent "Unresolved reference 'FontProvider'" error by ensuring very specific versions for all related Compose dependencies.