### PR TITLE
Fix: Modify Stretch Routine screen back button to navigate to Home

### DIFF
--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.dejvik.stretchhero.R
+import com.dejvik.stretchhero.navigation.Screen // Added import
 import com.dejvik.stretchhero.utils.TextToSpeechHelper
 import com.dejvik.stretchhero.ui.theme.MutedRed
 import com.dejvik.stretchhero.ui.theme.SoftWhite
@@ -87,7 +88,7 @@ fun StretchRoutineScreen(
                 navigationIcon = {
                     IconButton(onClick = {
                         viewModel.stopTimer()
-                        navController.popBackStack()
+                        navController.navigate(Screen.Home.route) { popUpTo(Screen.Home.route) { inclusive = true }; launchSingleTop = true }
                     }) {
                         Icon(Icons.Filled.ArrowBack, contentDescription = "Back", tint = SoftWhite)
                     }


### PR DESCRIPTION
The back button in the TopAppBar of the StretchRoutineScreen previously used popBackStack(), navigating to the previous screen in the hierarchy (usually the StretchLibraryScreen).

This change modifies the button's action to navigate directly to the HomeScreen (Screen.Home.route) and clears the navigation stack up to Home. This ensures that from the Stretch Routine screen, you are taken directly to the main Home screen as requested.