### PR TITLE
Add UI improvements

### DIFF
--- a/app/src/main/java/com/dejvik/stretchhero/navigation/StretchHeroNavHost.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/navigation/StretchHeroNavHost.kt
@@ -15,12 +15,12 @@ import androidx.navigation.navArgument
 import com.dejvik.stretchhero.ui.screens.HomeScreen // Added import
 import com.dejvik.stretchhero.ui.screens.StretchLibraryScreen
 import com.dejvik.stretchhero.ui.screens.StretchRoutineScreen
-import com.dejvik.stretchhero.ui.theme.DarkGray
+import androidx.compose.material3.MaterialTheme
 
 @Composable
 fun StretchHeroNavHost() {
     val navController = rememberNavController()
-    Scaffold(containerColor = DarkGray) { padding ->
+    Scaffold(containerColor = MaterialTheme.colorScheme.background) { padding ->
         NavHost(
             navController = navController,
             startDestination = Screen.Home.route, // Changed startDestination

--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/HomeScreen.kt
@@ -3,6 +3,7 @@ package com.dejvik.stretchhero.ui.screens
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -25,6 +26,7 @@ fun HomeScreen(navController: NavController) {
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
             .padding(16.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally

--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/RoutineViewModel.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/RoutineViewModel.kt
@@ -83,6 +83,16 @@ class RoutineViewModel : ViewModel() {
         }
     }
 
+    fun moveToPreviousStep() {
+        currentRoutine.value?.let { routine ->
+            if (currentStepIndex.value > 0) {
+                currentStepIndex.value--
+                val prevStep = routine.steps[currentStepIndex.value]
+                timeLeftInSeconds.value = prevStep.duration
+            }
+        }
+    }
+
     fun restartRoutine() {
         currentRoutine.value?.id?.let {
             loadRoutine(it)

--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchLibraryScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchLibraryScreen.kt
@@ -20,10 +20,12 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import com.dejvik.stretchhero.ui.theme.montserratFont
@@ -45,7 +47,7 @@ fun StretchLibraryScreen(navController: NavController) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color(0xFFF0F4F8)) // Light background color
+            .background(MaterialTheme.colorScheme.background)
             .padding(16.dp)
     ) {
         Text(
@@ -54,7 +56,7 @@ fun StretchLibraryScreen(navController: NavController) {
             fontFamily = montserratFont,
             fontWeight = FontWeight.Bold,
             modifier = Modifier.padding(bottom = 24.dp),
-            color = Color(0xFF333333) // Darker text color
+            color = MaterialTheme.colorScheme.onBackground
         )
         LazyColumn(verticalArrangement = Arrangement.spacedBy(16.dp)) {
             items(routines) { routine ->
@@ -66,6 +68,15 @@ fun StretchLibraryScreen(navController: NavController) {
 
 @Composable
 fun RoutineCard(routine: Routine, navController: NavController) {
+    val context = LocalContext.current
+    val imageResId = remember(routine.id) {
+        context.resources.getIdentifier(
+            routine.steps.firstOrNull()?.imageResIdName ?: "",
+            "drawable",
+            context.packageName
+        ).takeIf { it != 0 } ?: R.drawable.ic_stretch_placeholder
+    }
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -74,17 +85,15 @@ fun RoutineCard(routine: Routine, navController: NavController) {
             }
             .clip(RoundedCornerShape(12.dp)), // More rounded corners
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White)
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
     ) {
         Row(
             modifier = Modifier
                 .padding(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Placeholder for dynamic image loading based on routine
-            // For now, using a generic icon for all routines in the library view
             Image(
-                painter = painterResource(id = R.drawable.ic_stretch_placeholder), // Replace with actual dynamic logic if needed
+                painter = painterResource(id = imageResId),
                 contentDescription = routine.name,
                 modifier = Modifier
                     .size(80.dp) // Slightly larger image
@@ -98,14 +107,14 @@ fun RoutineCard(routine: Routine, navController: NavController) {
                     fontSize = 20.sp, // Slightly larger title
                     fontFamily = montserratFont,
                     fontWeight = FontWeight.SemiBold,
-                    color = Color(0xFF333333)
+                    color = MaterialTheme.colorScheme.onSurface
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = "Estimated time: ${routine.steps.sumOf { it.duration } / 60} min",
                     fontSize = 14.sp,
                     fontFamily = montserratFont,
-                    color = Color.Gray
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }

--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
@@ -8,13 +8,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -24,8 +23,6 @@ import androidx.navigation.NavController
 import com.dejvik.stretchhero.R
 import com.dejvik.stretchhero.navigation.Screen // Added import
 import com.dejvik.stretchhero.utils.TextToSpeechHelper
-import com.dejvik.stretchhero.ui.theme.MutedRed
-import com.dejvik.stretchhero.ui.theme.SoftWhite
 import com.dejvik.stretchhero.ui.theme.montserratFont
 
 @OptIn(ExperimentalMaterial3Api::class) // Added annotation
@@ -83,19 +80,19 @@ fun StretchRoutineScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(currentRoutine?.name ?: "Loading...", fontFamily = montserratFont, color = SoftWhite) },
+                title = { Text(currentRoutine?.name ?: "Loading...", fontFamily = montserratFont, color = MaterialTheme.colorScheme.onPrimary) },
                 navigationIcon = {
                     IconButton(onClick = {
                         viewModel.stopTimer()
                         navController.navigate(Screen.Home.route) { popUpTo(Screen.Home.route) { inclusive = true }; launchSingleTop = true }
                     }) {
-                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back", tint = SoftWhite)
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back", tint = MaterialTheme.colorScheme.onPrimary)
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MutedRed)
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary)
             )
         },
-        containerColor = Color.DarkGray
+        containerColor = MaterialTheme.colorScheme.background
     ) { paddingValues ->
 
         if (!routineFound) {
@@ -109,7 +106,7 @@ fun StretchRoutineScreen(
                 Text(
                     text = "Routine not found. Please go back and select a valid routine.",
                     fontSize = 20.sp,
-                    color = SoftWhite,
+                    color = MaterialTheme.colorScheme.onBackground,
                     fontFamily = montserratFont,
                     modifier = Modifier.padding(horizontal = 32.dp)
                 )
@@ -125,7 +122,7 @@ fun StretchRoutineScreen(
             ) {
                 // This case should ideally be less frequent if routineFound handles the primary "not found"
                 // Still, good for robustness if a loaded routine has no steps.
-                Text("Loading routine or routine has no steps...", fontSize = 20.sp, color = SoftWhite, fontFamily = montserratFont)
+                Text("Loading routine or routine has no steps...", fontSize = 20.sp, color = MaterialTheme.colorScheme.onBackground, fontFamily = montserratFont)
             }
             return@Scaffold
         }
@@ -143,8 +140,20 @@ fun StretchRoutineScreen(
                     text = currentStep.name,
                     fontSize = 24.sp,
                     fontFamily = montserratFont,
-                    color = SoftWhite,
-                    modifier = Modifier.padding(bottom = 8.dp)
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.padding(bottom = 4.dp)
+                )
+                Text(
+                    text = "Step ${currentStepIndex + 1} of ${currentRoutine!!.steps.size}",
+                    fontFamily = montserratFont,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+                LinearProgressIndicator(
+                    progress = (currentStepIndex + 1f) / currentRoutine!!.steps.size,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    color = MaterialTheme.colorScheme.primary
                 )
 
                 val imageResId = remember(currentStep.imageResIdName) {
@@ -169,7 +178,7 @@ fun StretchRoutineScreen(
                     text = if (isRunning || timeLeft < currentStep.duration) "$animatedTimeLeft s" else "${currentStep.duration} s",
                     fontSize = 48.sp,
                     fontFamily = montserratFont,
-                    color = SoftWhite,
+                    color = MaterialTheme.colorScheme.onBackground,
                     modifier = Modifier.padding(bottom = 16.dp)
                 )
             }
@@ -183,13 +192,12 @@ fun StretchRoutineScreen(
             ) {
                 IconButton(
                     onClick = {
-                        // This functionality needs to be added to ViewModel
-                        // For now, let's disable or think about how to implement "previous"
-                        // viewModel.moveToPreviousStep() // if implemented
+                        viewModel.stopTimer()
+                        viewModel.moveToPreviousStep()
                     },
-                    enabled = currentStepIndex > 0 // viewModel.canMoveToPrevious.value
+                    enabled = currentStepIndex > 0
                 ) {
-                    Icon(Icons.Filled.ArrowBack, contentDescription = "Previous Step", tint = SoftWhite, modifier = Modifier.size(48.dp))
+                    Icon(Icons.Filled.ArrowBack, contentDescription = "Previous Step", tint = MaterialTheme.colorScheme.onBackground, modifier = Modifier.size(48.dp))
                 }
 
                 IconButton(
@@ -198,28 +206,26 @@ fun StretchRoutineScreen(
                             viewModel.stopTimer()
                         } else {
                             viewModel.startStepTimer()
-                            // TTS is handled by LaunchedEffect(currentStep) when isRunning becomes true
                         }
                     },
                     modifier = Modifier.size(72.dp)
                 ) {
                     Icon(
-                        imageVector = if (isRunning) Icons.Filled.Refresh else Icons.Filled.PlayArrow, // Should be Pause icon if running
+                        imageVector = if (isRunning) Icons.Filled.Pause else Icons.Filled.PlayArrow,
                         contentDescription = if (isRunning) "Pause Timer" else "Start Timer",
-                        tint = SoftWhite,
+                        tint = MaterialTheme.colorScheme.onBackground,
                         modifier = Modifier.fillMaxSize()
                     )
                 }
 
                 IconButton(
                     onClick = {
-                        viewModel.stopTimer() // Stop current timer before moving
+                        viewModel.stopTimer()
                         viewModel.moveToNextStep()
-                         // TTS for next step handled by LaunchedEffect(currentStep)
                     },
                     enabled = currentStepIndex < (currentRoutine.steps.size - 1)
                 ) {
-                    Icon(Icons.Filled.ArrowForward, contentDescription = "Next Step", tint = SoftWhite, modifier = Modifier.size(48.dp))
+                    Icon(Icons.Filled.ArrowForward, contentDescription = "Next Step", tint = MaterialTheme.colorScheme.onBackground, modifier = Modifier.size(48.dp))
                 }
             }
         }


### PR DESCRIPTION
## Summary
- use theme colors across screens
- add routine progress indicator and pause icon
- implement previous step navigation logic
- show stretch-specific images in library

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684179e3e8148325905f06d2218ffe88