### PR TITLE
Fix Pause icon missing by adding material icons dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,8 @@ dependencies {
     // implementation("androidx.compose.material3:material3:1.1.2") // Removed for BOM
     implementation("androidx.navigation:navigation-compose:2.7.5")
     implementation("androidx.compose.ui:ui-text-google-fonts:1.6.7")
+    // Needed for Icons.Filled.Pause and other extended material icons
+    implementation("androidx.compose.material:material-icons-extended:1.6.7")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     // androidTestImplementation(platform(libs.androidx.compose.bom)) // Commented out for test as well


### PR DESCRIPTION
## Summary
- add missing material-icons dependency so Pause icon resolves

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841a45edee0832591409f4e57b5df70