### PR TITLE
Fix Google Fonts imports in Type.kt

### DIFF
--- a/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
@@ -2,14 +2,13 @@ package com.dejvik.stretchhero.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.googlefonts.Font
-import androidx.compose.ui.text.googlefonts.FontFamily
-import androidx.compose.ui.text.googlefonts.FontProvider
 import androidx.compose.ui.text.googlefonts.GoogleFont
 import com.dejvik.stretchhero.R
 
-private val provider = FontProvider(
+private val provider = GoogleFont.Provider(
     providerAuthority = "com.google.android.gms.fonts",
     providerPackage = "com.google.android.gms",
     certificates = R.array.com_google_android_gms_fonts_certs


### PR DESCRIPTION
## Summary
- fix imports for Google Fonts in Type.kt
- use `GoogleFont.Provider` for fonts

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841a7286d4c8325806f0208b98a7baa