### PR TITLE
Add logo and back button

### DIFF
--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.dejvik.stretchhero.ui.screens
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import com.dejvik.stretchhero.ui.theme.montserratFont
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -31,6 +33,12 @@ fun HomeScreen(navController: NavController) {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        Image(
+            painter = painterResource(id = com.dejvik.stretchhero.R.drawable.stretchhero_logo),
+            contentDescription = "App Logo",
+            modifier = Modifier.height(120.dp)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
         Text(
             text = "Stretch Hero",
             fontSize = 32.sp,

--- a/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/screens/StretchRoutineScreen.kt
@@ -228,6 +228,16 @@ fun StretchRoutineScreen(
                     Icon(Icons.Filled.ArrowForward, contentDescription = "Next Step", tint = MaterialTheme.colorScheme.onBackground, modifier = Modifier.size(48.dp))
                 }
             }
+
+            Button(
+                onClick = {
+                    viewModel.stopTimer()
+                    navController.popBackStack()
+                },
+                modifier = Modifier.padding(bottom = 16.dp)
+            ) {
+                Text("Back", fontFamily = montserratFont)
+            }
         }
     }
 }

--- a/app/src/main/res/drawable/stretchhero_logo.xml
+++ b/app/src/main/res/drawable/stretchhero_logo.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF9800"
+        android:pathData="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.46,13.97L5.82,21L12,17.27z"/>
+</vector>


### PR DESCRIPTION
## Summary
- show a brand logo on the home screen
- add a Back button to the routine screen

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841cbe8198c8325a36b573b7dafeab8