### PR TITLE
Fix GoogleFont provider resource reference

### DIFF
--- a/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
@@ -11,7 +11,7 @@ import com.dejvik.stretchhero.R
 private val provider = GoogleFont.Provider(
     providerAuthority = "com.google.android.gms.fonts",
     providerPackage = "com.google.android.gms",
-    certificates = R.array.com_google_android_gms_fonts_certs
+    certificates = com.google.android.gms.R.array.com_google_android_gms_fonts_certs
 )
 
 val montserratFont = FontFamily(


### PR DESCRIPTION
## Summary
- reference Google Play Services font certificate resource directly

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842811422848325ab4aebf09c4f09cb