### PR TITLE
Fix Google Font provider import

### DIFF
--- a/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.text.googlefonts.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.googlefonts.GoogleFont
-import com.dejvik.stretchhero.R
+import androidx.compose.ui.R
 
 private val provider = GoogleFont.Provider(
     providerAuthority = "com.google.android.gms.fonts",


### PR DESCRIPTION
## Summary
- use the Google Fonts certificates defined in `androidx.compose.ui` instead of the app resources

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68429610e948832598de9f81c04c4355