### PR TITLE
Fix google fonts provider resource

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-text-google-fonts:1.6.7")
     // Needed for Icons.Filled.Pause and other extended material icons
     implementation("androidx.compose.material:material-icons-extended:1.6.7")
+    implementation(libs.google.play.services.base)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     // androidTestImplementation(platform(libs.androidx.compose.bom)) // Commented out for test as well

--- a/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.text.googlefonts.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.googlefonts.GoogleFont
-import androidx.compose.ui.R
+import com.google.android.gms.R
 
 private val provider = GoogleFont.Provider(
     providerAuthority = "com.google.android.gms.fonts",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+google-play-services-base = { group = "com.google.android.gms", name = "play-services-base", version = "18.4.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- import Google Play Services `R` resource for fonts
- add Play Services base dependency for fonts certificates

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684296fc2e7c8325a78ba1d478050859