### PR TITLE
Fix font provider compilation error

### DIFF
--- a/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
+++ b/app/src/main/java/com/dejvik/stretchhero/ui/theme/Type.kt
@@ -2,22 +2,12 @@ package com.dejvik.stretchhero.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.googlefonts.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.googlefonts.GoogleFont
-import com.google.android.gms.R
 
-private val provider = GoogleFont.Provider(
-    providerAuthority = "com.google.android.gms.fonts",
-    providerPackage = "com.google.android.gms",
-    certificates = R.array.com_google_android_gms_fonts_certs
-)
-
-val montserratFont = FontFamily(
-    Font(googleFont = GoogleFont("Montserrat"), fontProvider = provider, weight = FontWeight.Normal),
-    Font(googleFont = GoogleFont("Montserrat"), fontProvider = provider, weight = FontWeight.Bold)
-)
+// Use a generic sans-serif font family to avoid relying on Google Play
+// Services resources which are unavailable in this project.
+val montserratFont = FontFamily.SansSerif
 
 val Typography = Typography(
     displayLarge = TextStyle(fontFamily = montserratFont),


### PR DESCRIPTION
## Summary
- update `Type.kt` to use a generic sans-serif font family instead of the Google Play Services font provider

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6843d21892708325a7c7df5bfa14d23a